### PR TITLE
Add About page and fix login autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
     "jsdom": "^26.1.0",
-    "vite": "^5.2.10"
+    "vite": "^5.2.10",
     "vitest": "^3.2.4"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import TopBar from './components/TopBar';
 import Sidebar from './components/Sidebar';
 import Home from './pages/Home';
 import Login from './pages/Login';
+import About from './pages/About';
 import './App.css';
 
 export default function App() {
@@ -18,6 +19,7 @@ export default function App() {
               <Routes>
                 <Route path="/" element={<Home />} />
                 <Route path="/login" element={<Login />} />
+                <Route path="/about" element={<About />} />
               </Routes>
             </div>
           </div>

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import App from '../App';
+
+describe('App routing', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    cleanup();
+  });
+
+  it('renders About page', () => {
+    window.history.pushState({}, '', '/about');
+    render(<App />);
+    expect(screen.getByText(/about super schedules/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/Login.test.jsx
+++ b/src/__tests__/Login.test.jsx
@@ -23,6 +23,8 @@ describe('Login page', () => {
     renderPage();
     expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/username/i)).toHaveAttribute('autocomplete', 'username');
+    expect(screen.getByLabelText(/password/i)).toHaveAttribute('autocomplete', 'current-password');
   });
 
   it('logs in', () => {

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <div>About Super Schedules</div>;
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -23,6 +23,7 @@ export default function Login() {
             value={username}
             onChange={(e) => setUsername(e.target.value)}
             aria-label="username"
+            autoComplete="username"
           />
         </label>
       </div>
@@ -34,6 +35,7 @@ export default function Login() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             aria-label="password"
+            autoComplete="current-password"
           />
         </label>
       </div>


### PR DESCRIPTION
## Summary
- add About page and route
- add autocomplete attributes to login fields
- test About route and login field attributes

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892349356188333a55cffcc9c90a845