### PR TITLE
feat: configure auth API endpoints

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://api.example.com

--- a/src/__tests__/Login.test.jsx
+++ b/src/__tests__/Login.test.jsx
@@ -2,7 +2,8 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Login from '../pages/Login';
 import { AuthProvider } from '../auth.jsx';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
 
 function renderPage() {
   return render(
@@ -27,11 +28,21 @@ describe('Login page', () => {
     expect(screen.getByLabelText(/password/i)).toHaveAttribute('autocomplete', 'current-password');
   });
 
-  it('logs in', () => {
+  it('logs in', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ token: 'test-token' }),
+    });
+
     renderPage();
     fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'a' } });
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'b' } });
     fireEvent.click(screen.getByText(/login/i));
-    expect(localStorage.getItem('token')).not.toBeNull();
+
+    await waitFor(() =>
+      expect(localStorage.getItem('token')).toBe('test-token')
+    );
+
+    globalThis.fetch.mockRestore();
   });
 });

--- a/src/auth.jsx
+++ b/src/auth.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useState } from 'react';
+import { AUTH_ENDPOINTS } from './constants/api.js';
 
 export const AuthContext = createContext(null);
 
@@ -10,13 +11,25 @@ export function AuthProvider({ children }) {
   });
 
   const login = async (username, password) => {
-    // Simulate API login returning token
-    const token = btoa(`${username}:${password}`);
+    const response = await fetch(AUTH_ENDPOINTS.login, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (!response.ok) {
+      throw new Error('Login failed');
+    }
+    const data = await response.json();
+    const token = data.token;
     localStorage.setItem('token', token);
     setUser({ token });
   };
 
-  const logout = () => {
+  const logout = async () => {
+    await fetch(AUTH_ENDPOINTS.logout, {
+      method: 'POST',
+      headers: user ? { Authorization: `Bearer ${user.token}` } : {},
+    });
     localStorage.removeItem('token');
     setUser(null);
   };

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -1,0 +1,11 @@
+const DEV_API_BASE_URL = 'http://localhost:8000';
+const PROD_API_BASE_URL = 'https://api.example.com';
+
+export const API_BASE_URL = import.meta.env.PROD
+  ? PROD_API_BASE_URL
+  : DEV_API_BASE_URL;
+
+export const AUTH_ENDPOINTS = {
+  login: `${API_BASE_URL}/auth/login/`,
+  logout: `${API_BASE_URL}/auth/logout/`,
+};


### PR DESCRIPTION
## Summary
- use environment-specific constants for auth API URLs
- call backend auth endpoints from auth context
- mock fetch in login tests

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6892456336f083338adb8ad21767b519