### PR TITLE
Use JWT token endpoints for authentication

### DIFF
--- a/src/__tests__/Login.test.jsx
+++ b/src/__tests__/Login.test.jsx
@@ -31,7 +31,8 @@ describe('Login page', () => {
   it('logs in', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ token: 'test-token' }),
+      json: () =>
+        Promise.resolve({ access: 'test-access', refresh: 'test-refresh' }),
     });
 
     renderPage();
@@ -39,9 +40,10 @@ describe('Login page', () => {
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'b' } });
     fireEvent.click(screen.getByText(/login/i));
 
-    await waitFor(() =>
-      expect(localStorage.getItem('token')).toBe('test-token')
-    );
+    await waitFor(() => {
+      expect(localStorage.getItem('token')).toBe('test-access');
+      expect(localStorage.getItem('refresh')).toBe('test-refresh');
+    });
 
     globalThis.fetch.mockRestore();
   });

--- a/src/__tests__/TopBar.test.jsx
+++ b/src/__tests__/TopBar.test.jsx
@@ -5,7 +5,9 @@ import { AuthProvider, AuthContext } from '../auth.jsx';
 import { describe, it, expect, afterEach, vi } from 'vitest';
 
 function renderWithAuth(ui, { user } = {}) {
-  const value = user ? { user, login: vi.fn(), logout: vi.fn() } : undefined;
+  const value = user
+    ? { user, login: vi.fn(), logout: vi.fn(), refreshToken: vi.fn() }
+    : undefined;
   return render(
     <MemoryRouter>
       {value ? (

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -6,6 +6,6 @@ export const API_BASE_URL = import.meta.env.PROD
   : DEV_API_BASE_URL;
 
 export const AUTH_ENDPOINTS = {
-  login: `${API_BASE_URL}/auth/login/`,
-  logout: `${API_BASE_URL}/auth/logout/`,
+  login: `${API_BASE_URL}/api/token/`,
+  refresh: `${API_BASE_URL}/api/token/refresh/`,
 };


### PR DESCRIPTION
## Summary
- switch auth constants to Django's `/api/token/` and `/api/token/refresh/`
- store access/refresh tokens and expose `refreshToken` in auth context
- update tests for JWT-based login flow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68924dcdb2848333ab85eeb60da4d500