### PR TITLE
Add user registration flow with email verification notice

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,8 @@ import Sidebar from './components/Sidebar';
 import Home from './pages/Home';
 import Login from './pages/Login';
 import About from './pages/About';
+import CreateUser from './pages/CreateUser';
+import VerifyAccount from './pages/VerifyAccount';
 import './App.css';
 
 export default function App() {
@@ -20,6 +22,8 @@ export default function App() {
                 <Route path="/" element={<Home />} />
                 <Route path="/login" element={<Login />} />
                 <Route path="/about" element={<About />} />
+                <Route path="/create-user" element={<CreateUser />} />
+                <Route path="/verify-account" element={<VerifyAccount />} />
               </Routes>
             </div>
           </div>

--- a/src/__tests__/CreateUser.test.jsx
+++ b/src/__tests__/CreateUser.test.jsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import CreateUser from '../pages/CreateUser';
+
+describe('CreateUser page', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderWithRouter() {
+    return render(
+      <MemoryRouter initialEntries={[ '/create-user' ]}>
+        <Routes>
+          <Route path="/create-user" element={<CreateUser />} />
+          <Route path="/verify-account" element={<p>verify</p>} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it('renders form', () => {
+    renderWithRouter();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/an email will be sent to verify your account/i)
+    ).toBeInTheDocument();
+  });
+
+  it('submits and navigates to verify page', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+
+    renderWithRouter();
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/^password$/i), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByText(/create account/i));
+
+    await waitFor(() => {
+      expect(screen.getByText(/verify/i)).toBeInTheDocument();
+    });
+
+    globalThis.fetch.mockRestore();
+  });
+});

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -8,4 +8,5 @@ export const API_BASE_URL = import.meta.env.PROD
 export const AUTH_ENDPOINTS = {
   login: `${API_BASE_URL}/api/token/`,
   refresh: `${API_BASE_URL}/api/token/refresh/`,
+  register: `${API_BASE_URL}/api/users/`,
 };

--- a/src/pages/CreateUser.jsx
+++ b/src/pages/CreateUser.jsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AUTH_ENDPOINTS } from '../constants/api.js';
+
+export default function CreateUser() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    const response = await fetch(AUTH_ENDPOINTS.register, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (!response.ok) {
+      setError('User creation failed');
+      return;
+    }
+    navigate('/verify-account');
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            aria-label="email"
+            autoComplete="email"
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            aria-label="password"
+            autoComplete="new-password"
+          />
+        </label>
+      </div>
+      <p>An email will be sent to verify your account.</p>
+      {error && <div role="alert">{error}</div>}
+      <button type="submit">Create account</button>
+    </form>
+  );
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -41,7 +41,9 @@ export default function Login() {
       </div>
       <button type="submit">Login</button>
       <div>
-        <button type="button">Create account</button>
+        <button type="button" onClick={() => navigate('/create-user')}>
+          Create account
+        </button>
         <button type="button">I lost my password</button>
       </div>
     </form>

--- a/src/pages/VerifyAccount.jsx
+++ b/src/pages/VerifyAccount.jsx
@@ -1,0 +1,5 @@
+export default function VerifyAccount() {
+  return (
+    <p>Click the link in your email to verify your account.</p>
+  );
+}


### PR DESCRIPTION
## Summary
- add user creation form with email/password and verification email notice
- provide confirmation page instructing users to verify their email
- wire new routes and navigation for account creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68925c3de574833398bf2453f34b0f30