### PR TITLE
Enable calendar month navigation with dynamic event fetching

### DIFF
--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { vi, describe, it, expect, afterEach } from 'vitest';
 vi.mock('react-big-calendar', () => ({
-  Calendar: () => <div>mock calendar</div>,
+  Calendar: ({ onRangeChange }) => {
+    React.useEffect(() => {
+      onRangeChange?.([ new Date('2025-01-01'), new Date('2025-01-31') ]);
+    }, [ onRangeChange ]);
+    return <div>mock calendar</div>;
+  },
   dateFnsLocalizer: () => () => {},
 }));
 import { render, screen, cleanup, waitFor } from '@testing-library/react';

--- a/src/__tests__/Calendar.test.jsx
+++ b/src/__tests__/Calendar.test.jsx
@@ -4,7 +4,12 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import CalendarPage from '../pages/Calendar.jsx';
 
 vi.mock('react-big-calendar', () => ({
-  Calendar: () => <div data-testid="calendar" />,
+  Calendar: ({ onRangeChange }) => {
+    React.useEffect(() => {
+      onRangeChange?.([ new Date('2025-01-01'), new Date('2025-01-31') ]);
+    }, [ onRangeChange ]);
+    return <div data-testid="calendar">mock calendar</div>;
+  },
   dateFnsLocalizer: () => () => {},
 }));
 

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react';
 import { Calendar as BigCalendar, dateFnsLocalizer } from 'react-big-calendar';
-import { format, parse, startOfWeek, getDay } from 'date-fns';
+import {
+  format,
+  parse,
+  startOfWeek,
+  getDay,
+} from 'date-fns';
 import { enUS } from 'date-fns/locale';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import './Calendar.css';
@@ -21,17 +26,23 @@ const localizer = dateFnsLocalizer({
 export default function CalendarPage() {
   const [events, setEvents] = useState([]);
   const [selectedEvent, setSelectedEvent] = useState(null);
+  const [range, setRange] = useState(null);
 
   useEffect(() => {
+    if (!range) return;
     async function loadEvents() {
       try {
-        const res = await fetch(EVENTS_ENDPOINTS.list);
+        const params = new URLSearchParams({
+          start: range.start.toISOString(),
+          end: range.end.toISOString(),
+        });
+        const res = await fetch(`${EVENTS_ENDPOINTS.list}?${params}`);
         if (res.ok) {
           const data = await res.json();
           const mapped = data.map((e) => ({
             ...e,
-            start: new Date(e.start),
-            end: new Date(e.end),
+            start: new Date(e.start ?? e.start_time),
+            end: new Date(e.end ?? e.end_time),
           }));
           setEvents(mapped);
         }
@@ -40,7 +51,28 @@ export default function CalendarPage() {
       }
     }
     loadEvents();
-  }, []);
+  }, [range]);
+
+  const handleRangeChange = (r) => {
+    let start;
+    let end;
+    if (Array.isArray(r)) {
+      start = r[0];
+      end = r[r.length - 1];
+    } else {
+      ({ start, end } = r);
+    }
+    setRange((prev) => {
+      if (
+        prev &&
+        prev.start.getTime() === start.getTime() &&
+        prev.end.getTime() === end.getTime()
+      ) {
+        return prev;
+      }
+      return { start, end };
+    });
+  };
 
   return (
     <div className="calendar-page">
@@ -53,6 +85,7 @@ export default function CalendarPage() {
         views={[ 'month', 'week', 'day' ]}
         style={{ height: 500 }}
         onSelectEvent={(event) => setSelectedEvent(event)}
+        onRangeChange={handleRangeChange}
       />
       {selectedEvent && (
         <dialog open className="event-dialog">


### PR DESCRIPTION
## Summary
- load calendar events for the visible range from `/api/v1/events`
- update calendar and app tests to mock range changes
- format calendar component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68929a394090833387c59260a95e06d4