### PR TITLE
Fix calendar event fetch auth and duplicate calls

### DIFF
--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -6,6 +6,7 @@ vi.mock('react-big-calendar', () => ({
 }));
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import App from '../App';
+import { EVENTS_ENDPOINTS } from '../constants/api.js';
 
 describe('App routing', () => {
   afterEach(() => {
@@ -20,6 +21,7 @@ describe('App routing', () => {
   });
 
   it('renders Calendar page', async () => {
+    window.localStorage.setItem('token', 'test-token');
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve([]),
@@ -28,7 +30,10 @@ describe('App routing', () => {
     render(<App />);
     expect(screen.getByRole('heading', { name: /calendar/i })).toBeInTheDocument();
     await waitFor(() => {
-      expect(globalThis.fetch).toHaveBeenCalled();
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(EVENTS_ENDPOINTS.list, {
+      headers: { Authorization: 'Bearer test-token' },
     });
     globalThis.fetch.mockRestore();
   });

--- a/src/__tests__/Calendar.test.jsx
+++ b/src/__tests__/Calendar.test.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen, waitFor, cleanup } from '@testing-library/react';
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import CalendarPage from '../pages/Calendar.jsx';
+import { AuthContext } from '../auth.jsx';
+import { EVENTS_ENDPOINTS } from '../constants/api.js';
 
 vi.mock('react-big-calendar', () => ({
   Calendar: () => <div data-testid="calendar" />,
@@ -18,12 +20,20 @@ describe('Calendar page', () => {
       ok: true,
       json: () => Promise.resolve([]),
     });
+    render(
+      <AuthContext.Provider value={{ user: { token: 'test-token' } }}>
+        <CalendarPage />
+      </AuthContext.Provider>,
+    );
 
-    render(<CalendarPage />);
     expect(screen.getByRole('heading', { name: /calendar/i })).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(globalThis.fetch).toHaveBeenCalled();
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(EVENTS_ENDPOINTS.list, {
+      headers: { Authorization: 'Bearer test-token' },
     });
 
     globalThis.fetch.mockRestore();


### PR DESCRIPTION
## Summary
- include auth token when fetching events and avoid duplicate requests
- update Calendar and App tests to assert authorized fetch

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892aaed1dd48333b128407f6938e31d