### PR TITLE
feat: add date range inputs to calendar

### DIFF
--- a/src/pages/Calendar.css
+++ b/src/pages/Calendar.css
@@ -2,6 +2,17 @@
   padding: 1rem;
 }
 
+.range-controls {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.range-controls label {
+  display: flex;
+  flex-direction: column;
+}
+
 .event-dialog {
   padding: 1rem;
 }

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -34,6 +34,8 @@ export default function CalendarPage() {
   const [selectedEvent, setSelectedEvent] = useState(null);
   const [currentView, setCurrentView] = useState('month');
   const [currentDate, setCurrentDate] = useState(new Date());
+  const [rangeStart, setRangeStart] = useState('');
+  const [rangeEnd, setRangeEnd] = useState('');
 
   const { user } = useAuth();
 
@@ -43,6 +45,10 @@ export default function CalendarPage() {
     }
 
     const { start, end } = (() => {
+      if (rangeStart && rangeEnd) {
+        return { start: new Date(rangeStart), end: new Date(rangeEnd) };
+      }
+
       switch (currentView) {
         case 'day':
           return { start: startOfDay(currentDate), end: endOfDay(currentDate) };
@@ -84,11 +90,29 @@ export default function CalendarPage() {
     }
 
     loadEvents();
-  }, [user, currentView, currentDate]);
+  }, [user, currentView, currentDate, rangeStart, rangeEnd]);
 
   return (
     <div className="calendar-page">
       <h1>Calendar</h1>
+      <div className="range-controls">
+        <label>
+          Start
+          <input
+            type="date"
+            value={rangeStart}
+            onChange={(e) => setRangeStart(e.target.value)}
+          />
+        </label>
+        <label>
+          End
+          <input
+            type="date"
+            value={rangeEnd}
+            onChange={(e) => setRangeEnd(e.target.value)}
+          />
+        </label>
+      </div>
       <BigCalendar
         localizer={localizer}
         events={events}


### PR DESCRIPTION
## Summary
- add start/end date range fields to calendar
- automatically reload events when range changes
- basic layout styling for date range controls

## Testing
- `CI=1 npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68939e5852608333852679e423951be9