### PR TITLE
Fix calendar event range and tooltip details

### DIFF
--- a/src/__tests__/Calendar.test.jsx
+++ b/src/__tests__/Calendar.test.jsx
@@ -40,11 +40,23 @@ describe('Calendar page', () => {
     const firstUrl = globalThis.fetch.mock.calls[0][0];
     const parsed1 = new URL(firstUrl);
     expect(parsed1.pathname).toBe(new URL(EVENTS_ENDPOINTS.list).pathname);
-    expect(parsed1.searchParams.get('start')).toBeTruthy();
-    expect(parsed1.searchParams.get('end')).toBeTruthy();
+    expect(parsed1.searchParams.get('start')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(parsed1.searchParams.get('end')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(globalThis.fetch.mock.calls[0][1]).toEqual({
       headers: { Authorization: 'Bearer test-token' },
     });
+
+    expect(typeof handlers.tooltipAccessor).toBe('function');
+    const tooltip = handlers.tooltipAccessor({
+      title: 'title',
+      description: 'desc',
+      location: 'room',
+      start: new Date('2024-01-01T10:00:00'),
+      end: new Date('2024-01-01T11:00:00'),
+    });
+    expect(tooltip).toContain('title');
+    expect(tooltip).toContain('desc');
+    expect(tooltip).toContain('room');
 
     handlers.onNavigate(new Date('2025-02-01'));
 

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -64,8 +64,8 @@ export default function CalendarPage() {
     })();
 
     const params = new URLSearchParams({
-      start: start.toISOString(),
-      end: end.toISOString(),
+      start: format(start, 'yyyy-MM-dd'),
+      end: format(end, 'yyyy-MM-dd'),
     });
 
     async function loadEvents() {
@@ -125,6 +125,17 @@ export default function CalendarPage() {
         onNavigate={(date) => setCurrentDate(date)}
         style={{ height: 500 }}
         onSelectEvent={(event) => setSelectedEvent(event)}
+        tooltipAccessor={(event) => {
+          const parts = [event.title];
+          if (event.description) parts.push(event.description);
+          if (event.location) parts.push(event.location);
+          if (event.start && event.end) {
+            parts.push(
+              `${format(event.start, 'Pp')} - ${format(event.end, 'Pp')}`,
+            );
+          }
+          return parts.join('\n');
+        }}
       />
       {selectedEvent && (
         <dialog open className="event-dialog">


### PR DESCRIPTION
## Summary
- send calendar event range as dates instead of datetimes
- show event details in calendar tooltips
- add tests for date-only params and tooltip accessor

## Testing
- `npm run lint`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6893a1146f5c8333a451af3bbeb26c9c