### PR TITLE
Improve create user form styling and fields

### DIFF
--- a/src/__tests__/CreateUser.test.jsx
+++ b/src/__tests__/CreateUser.test.jsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { waitFor } from '@testing-library/react';
+import { AUTH_ENDPOINTS } from '../constants/api.js';
 import CreateUser from '../pages/CreateUser';
 
 describe('CreateUser page', () => {
@@ -22,8 +23,11 @@ describe('CreateUser page', () => {
 
   it('renders form', () => {
     renderWithRouter();
+    expect(screen.getByLabelText(/first name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/last name/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/zip code/i)).toBeInTheDocument();
     expect(
       screen.getByText(/an email will be sent to verify your account/i)
     ).toBeInTheDocument();
@@ -36,17 +40,41 @@ describe('CreateUser page', () => {
     });
 
     renderWithRouter();
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: 'John' },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: 'Doe' },
+    });
     fireEvent.change(screen.getByLabelText(/email/i), {
       target: { value: 'test@example.com' },
     });
     fireEvent.change(screen.getByLabelText(/^password$/i), {
       target: { value: 'secret' },
     });
+    fireEvent.change(screen.getByLabelText(/zip code/i), {
+      target: { value: '12345' },
+    });
     fireEvent.click(screen.getByText(/create account/i));
 
     await waitFor(() => {
       expect(screen.getByText(/verify/i)).toBeInTheDocument();
     });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      AUTH_ENDPOINTS.register,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'test@example.com',
+          password: 'secret',
+          firstName: 'John',
+          lastName: 'Doe',
+          zipCode: '12345',
+        }),
+      }
+    );
 
     globalThis.fetch.mockRestore();
   });

--- a/src/pages/CreateUser.jsx
+++ b/src/pages/CreateUser.jsx
@@ -4,8 +4,11 @@ import { AUTH_ENDPOINTS } from '../constants/api.js';
 
 export default function CreateUser() {
   const navigate = useNavigate();
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [zipCode, setZipCode] = useState('');
   const [error, setError] = useState(null);
 
   const handleSubmit = async (e) => {
@@ -14,7 +17,13 @@ export default function CreateUser() {
     const response = await fetch(AUTH_ENDPOINTS.register, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({
+        email,
+        password,
+        firstName,
+        lastName,
+        zipCode,
+      }),
     });
     if (!response.ok) {
       setError('User creation failed');
@@ -24,34 +33,91 @@ export default function CreateUser() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <div>
-        <label>
-          Email
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            aria-label="email"
-            autoComplete="email"
-          />
-        </label>
-      </div>
-      <div>
-        <label>
-          Password
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            aria-label="password"
-            autoComplete="new-password"
-          />
-        </label>
-      </div>
-      <p>An email will be sent to verify your account.</p>
-      {error && <div role="alert">{error}</div>}
-      <button type="submit">Create account</button>
-    </form>
+    <div className="container mt-4">
+      <form
+        onSubmit={handleSubmit}
+        className="p-4 border rounded bg-warning-subtle"
+      >
+        <div className="mb-3">
+          <label className="form-label">
+            First name
+            <input
+              type="text"
+              className="form-control"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              aria-label="first name"
+              autoComplete="given-name"
+            />
+          </label>
+        </div>
+        <div className="mb-3">
+          <label className="form-label">
+            Last name
+            <input
+              type="text"
+              className="form-control"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              aria-label="last name"
+              autoComplete="family-name"
+            />
+          </label>
+        </div>
+        <div className="mb-3">
+          <label className="form-label">
+            Email
+            <input
+              type="email"
+              className="form-control"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              aria-label="email"
+              autoComplete="email"
+            />
+          </label>
+        </div>
+        <div className="mb-3">
+          <label className="form-label">
+            Password
+            <input
+              type="password"
+              className="form-control"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              aria-label="password"
+              autoComplete="new-password"
+            />
+          </label>
+        </div>
+        <div className="mb-3">
+          <label className="form-label">
+            Zip code
+            <input
+              type="text"
+              className="form-control"
+              value={zipCode}
+              onChange={(e) => setZipCode(e.target.value)}
+              aria-label="zip code"
+              autoComplete="postal-code"
+            />
+          </label>
+        </div>
+        <p>An email will be sent to verify your account.</p>
+        {error && <div role="alert">{error}</div>}
+        <div className="d-flex justify-content-between mt-4">
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => navigate('/login')}
+          >
+            Cancel
+          </button>
+          <button type="submit" className="btn btn-primary">
+            Create account
+          </button>
+        </div>
+      </form>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- style create user form with border, light yellow background, and spaced action buttons
- add first name, last name, and zip code fields to registration
- expand tests to cover new fields and submission payload

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893c612fafc83338a906de060119237