### PR TITLE
feat(auth): auto refresh tokens and session expiry

### DIFF
--- a/src/__tests__/Calendar.test.jsx
+++ b/src/__tests__/Calendar.test.jsx
@@ -25,8 +25,13 @@ describe('Calendar page', () => {
       ok: true,
       json: () => Promise.resolve([]),
     });
+    const authFetch = (url, options) =>
+      globalThis.fetch(url, {
+        ...options,
+        headers: { Authorization: 'Bearer test-token', ...(options?.headers || {}) },
+      });
     render(
-      <AuthContext.Provider value={{ user: { token: 'test-token' } }}>
+      <AuthContext.Provider value={{ user: { token: 'test-token' }, authFetch }}>
         <CalendarPage />
       </AuthContext.Provider>,
     );

--- a/src/__tests__/TopBar.test.jsx
+++ b/src/__tests__/TopBar.test.jsx
@@ -6,7 +6,13 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 
 function renderWithAuth(ui, { user } = {}) {
   const value = user
-    ? { user, login: vi.fn(), logout: vi.fn(), refreshToken: vi.fn() }
+    ? {
+        user,
+        login: vi.fn(),
+        logout: vi.fn(),
+        refreshToken: vi.fn(),
+        authFetch: vi.fn(),
+      }
     : undefined;
   return render(
     <MemoryRouter>

--- a/src/auth.jsx
+++ b/src/auth.jsx
@@ -1,6 +1,32 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useContext, useState } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+} from 'react';
 import { AUTH_ENDPOINTS } from './constants/api.js';
+
+// Helper to decode a JWT and extract its payload. Returns null on failure.
+function parseJwt(token) {
+  try {
+    const base64Url = token.split('.')[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map((c) => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
+        .join(''),
+    );
+    return JSON.parse(jsonPayload);
+  } catch {
+    return null;
+  }
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 export const AuthContext = createContext(null);
 
@@ -8,8 +34,49 @@ export function AuthProvider({ children }) {
   const [user, setUser] = useState(() => {
     const token = localStorage.getItem('token');
     const refresh = localStorage.getItem('refresh');
-    return token ? { token, refresh } : null;
+    if (!token) return null;
+    const tokenPayload = parseJwt(token) || {};
+    const refreshPayload = parseJwt(refresh || '') || {};
+    return {
+      token,
+      refresh,
+      tokenExp: tokenPayload.exp,
+      refreshExp: refreshPayload.exp,
+    };
   });
+
+  const logoutTimerRef = useRef(null);
+
+  const logout = useCallback(() => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('refresh');
+    localStorage.removeItem('loginTime');
+    setUser(null);
+  }, []);
+
+  useEffect(() => {
+    if (!user) {
+      if (logoutTimerRef.current) {
+        clearTimeout(logoutTimerRef.current);
+      }
+      return;
+    }
+    if (!localStorage.getItem('loginTime')) {
+      localStorage.setItem('loginTime', String(Date.now()));
+    }
+    const loginTime = Number(localStorage.getItem('loginTime'));
+    const remaining = ONE_DAY_MS - (Date.now() - loginTime);
+    if (remaining <= 0) {
+      logout();
+    } else {
+      logoutTimerRef.current = setTimeout(logout, remaining);
+    }
+    return () => {
+      if (logoutTimerRef.current) {
+        clearTimeout(logoutTimerRef.current);
+      }
+    };
+  }, [user, logout]);
 
   const login = async (username, password) => {
     const response = await fetch(AUTH_ENDPOINTS.login, {
@@ -24,13 +91,26 @@ export function AuthProvider({ children }) {
     const { access, refresh } = data;
     localStorage.setItem('token', access);
     localStorage.setItem('refresh', refresh);
-    setUser({ token: access, refresh });
+    localStorage.setItem('loginTime', String(Date.now()));
+    const accessPayload = parseJwt(access) || {};
+    const refreshPayload = parseJwt(refresh) || {};
+    setUser({
+      token: access,
+      refresh,
+      tokenExp: accessPayload.exp,
+      refreshExp: refreshPayload.exp,
+    });
   };
 
   const refreshToken = async () => {
     const storedRefresh = localStorage.getItem('refresh');
     if (!storedRefresh) {
       throw new Error('No refresh token');
+    }
+    const refreshPayload = parseJwt(storedRefresh) || {};
+    if (refreshPayload.exp && refreshPayload.exp * 1000 < Date.now()) {
+      logout();
+      throw new Error('Refresh token expired');
     }
     const response = await fetch(AUTH_ENDPOINTS.refresh, {
       method: 'POST',
@@ -43,19 +123,45 @@ export function AuthProvider({ children }) {
     }
     const data = await response.json();
     const access = data.access;
+    const accessPayload = parseJwt(access) || {};
     localStorage.setItem('token', access);
-    setUser({ token: access, refresh: storedRefresh });
+    setUser({
+      token: access,
+      refresh: storedRefresh,
+      tokenExp: accessPayload.exp,
+      refreshExp: refreshPayload.exp,
+    });
     return access;
   };
 
-  const logout = () => {
-    localStorage.removeItem('token');
-    localStorage.removeItem('refresh');
-    setUser(null);
+  const getValidToken = async () => {
+    if (!user) {
+      throw new Error('Not authenticated');
+    }
+    const loginTime = Number(localStorage.getItem('loginTime'));
+    if (loginTime && Date.now() - loginTime > ONE_DAY_MS) {
+      logout();
+      throw new Error('Session expired');
+    }
+    if (user.tokenExp && user.tokenExp * 1000 < Date.now()) {
+      return refreshToken();
+    }
+    return user.token;
+  };
+
+  const authFetch = async (url, options = {}) => {
+    const token = await getValidToken();
+    const headers = {
+      ...(options.headers || {}),
+      Authorization: `Bearer ${token}`,
+    };
+    return fetch(url, { ...options, headers });
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, logout, refreshToken }}>
+    <AuthContext.Provider
+      value={{ user, login, logout, refreshToken, authFetch }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -37,7 +37,7 @@ export default function CalendarPage() {
   const [rangeStart, setRangeStart] = useState('');
   const [rangeEnd, setRangeEnd] = useState('');
 
-  const { user } = useAuth();
+  const { user, authFetch } = useAuth();
 
   useEffect(() => {
     if (!user?.token) {
@@ -70,11 +70,9 @@ export default function CalendarPage() {
 
     async function loadEvents() {
       try {
-        const res = await fetch(`${EVENTS_ENDPOINTS.list}?${params.toString()}`, {
-          headers: {
-            Authorization: `Bearer ${user.token}`,
-          },
-        });
+        const res = await authFetch(
+          `${EVENTS_ENDPOINTS.list}?${params.toString()}`,
+        );
         if (res.ok) {
           const data = await res.json();
           const mapped = data.map((e) => ({
@@ -90,7 +88,7 @@ export default function CalendarPage() {
     }
 
     loadEvents();
-  }, [user, currentView, currentDate, rangeStart, rangeEnd]);
+  }, [user, authFetch, currentView, currentDate, rangeStart, rangeEnd]);
 
   return (
     <div className="calendar-page">


### PR DESCRIPTION
## Summary
- add JWT parsing, refresh, and 24-hour logout timer in auth provider
- centralize API requests with `authFetch` that refreshes tokens automatically
- update calendar page and tests to use new auth fetch

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893cb9bc1ec8333bd591f7712b1ffcc