### PR TITLE
feat: add password reset flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import About from './pages/About';
 import CreateUser from './pages/CreateUser';
 import VerifyAccount from './pages/VerifyAccount';
 import Calendar from './pages/Calendar';
+import ResetPassword from './pages/ResetPassword';
 import './App.css';
 
 export default function App() {
@@ -28,6 +29,7 @@ export default function App() {
                 <Route path="/about" element={<About />} />
                 <Route path="/create-user" element={<CreateUser />} />
                 <Route path="/verify-account" element={<VerifyAccount />} />
+                <Route path="/reset-password" element={<ResetPassword />} />
                 <Route path="/calendar" element={<Calendar />} />
               </Routes>
             </div>

--- a/src/__tests__/Login.test.jsx
+++ b/src/__tests__/Login.test.jsx
@@ -4,6 +4,7 @@ import Login from '../pages/Login';
 import { AuthProvider } from '../auth.jsx';
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { waitFor } from '@testing-library/react';
+import { AUTH_ENDPOINTS } from '../constants/api.js';
 
 function renderPage() {
   return render(
@@ -43,6 +44,47 @@ describe('Login page', () => {
     await waitFor(() => {
       expect(localStorage.getItem('token')).toBe('test-access');
       expect(localStorage.getItem('refresh')).toBe('test-refresh');
+    });
+
+    globalThis.fetch.mockRestore();
+  });
+
+  it('shows error on failed login', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({ ok: false });
+
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'a' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'b' } });
+    fireEvent.click(screen.getByText(/login/i));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /Incorrect username or password, or the account has not been validated./i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    globalThis.fetch.mockRestore();
+  });
+
+  it('requests password reset', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({ ok: true });
+
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByText(/i lost my password/i));
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        AUTH_ENDPOINTS.reset,
+        expect.objectContaining({ method: 'POST' }),
+      );
+      expect(
+        screen.getByText(/check your email for a password reset link/i),
+      ).toBeInTheDocument();
     });
 
     globalThis.fetch.mockRestore();

--- a/src/__tests__/ResetPassword.test.jsx
+++ b/src/__tests__/ResetPassword.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import ResetPassword from '../pages/ResetPassword';
+import { AUTH_ENDPOINTS } from '../constants/api.js';
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/reset-password?token=abc']}>
+      <Routes>
+        <Route path="/reset-password" element={<ResetPassword />} />
+        <Route path="/login" element={<div>login</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ResetPassword page', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('submits new password', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({ ok: true });
+
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/new password/i), {
+      target: { value: 'abc' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'abc' },
+    });
+    fireEvent.click(screen.getByText(/reset password/i));
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        AUTH_ENDPOINTS.resetConfirm,
+        expect.objectContaining({ method: 'POST' }),
+      );
+      expect(
+        screen.getByText(/your password has been reset/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -14,6 +14,8 @@ export const AUTH_ENDPOINTS = {
   login: `${API_ROOT}/token/`,
   refresh: `${API_ROOT}/token/refresh/`,
   register: `${API_ROOT}/users/`,
+  reset: `${API_ROOT}/reset/`,
+  resetConfirm: `${API_ROOT}/reset/confirm/`,
 };
 
 export const EVENTS_ENDPOINTS = {

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { AUTH_ENDPOINTS } from '../constants/api.js';
+
+export default function ResetPassword() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token') || '';
+  const navigate = useNavigate();
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [attempted, setAttempted] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setAttempted(true);
+    setMessage('');
+    if (!password || password !== confirm) {
+      return;
+    }
+    try {
+      setLoading(true);
+      const response = await fetch(AUTH_ENDPOINTS.resetConfirm, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, password }),
+      });
+      if (response.ok) {
+        setMessage('Your password has been reset. You can now log in.');
+        setTimeout(() => navigate('/login'), 2000);
+      } else {
+        throw new Error('Reset failed');
+      }
+    } catch {
+      setMessage('Unable to reset password.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <form
+        onSubmit={handleSubmit}
+        className="p-4 border rounded bg-warning-subtle"
+      >
+        <div className="mb-3">
+          <label className="form-label">
+            New Password
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className={`form-control ${attempted && !password ? 'is-invalid' : ''}`}
+              aria-label="new-password"
+            />
+          </label>
+        </div>
+        <div className="mb-3">
+          <label className="form-label">
+            Confirm Password
+            <input
+              type="password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              className={`form-control ${attempted && (confirm !== password || !confirm) ? 'is-invalid' : ''}`}
+              aria-label="confirm-password"
+            />
+          </label>
+        </div>
+        {message && (
+          <div className="alert alert-info" role="alert">
+            {message}
+          </div>
+        )}
+        <div className="mt-4">
+          <button type="submit" className="btn btn-primary" disabled={loading}>
+            {loading ? 'Saving…' : 'Reset Password'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API endpoints and route for password reset
- improve login with unified error messaging and password reset requests
- implement password reset confirmation page

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893d727932083339634a105b3769780