### PR TITLE
Refine navigation colors and login button

### DIFF
--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -2,4 +2,5 @@
   width: 260px;
   height: 100vh;
   box-sizing: border-box;
+  background-color: #f5deb3;
 }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -3,7 +3,7 @@ import './Sidebar.css';
 
 export default function Sidebar() {
   return (
-    <aside className="sidebar bg-warning p-3">
+    <aside className="sidebar p-3 text-dark">
       <nav className="nav flex-column">
         <Link className="nav-link text-dark" to="/">
           Home

--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -1,6 +1,7 @@
 .topbar {
   display: flex;
   align-items: center;
+  background-color: #d2b48c;
 }
 
 .user-menu {

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -8,7 +8,7 @@ export default function TopBar({ onToggleSidebar }) {
   const [open, setOpen] = useState(false);
 
   return (
-    <header className="topbar navbar bg-warning px-3">
+    <header className="topbar navbar px-3 text-dark">
       <button
         className="btn btn-outline-dark me-2"
         aria-label="Toggle sidebar"
@@ -38,7 +38,7 @@ export default function TopBar({ onToggleSidebar }) {
           )}
         </div>
       ) : (
-        <Link className="ms-auto" to="/login">
+        <Link className="btn btn-outline-dark ms-auto fs-5" to="/login">
           Login
         </Link>
       )}


### PR DESCRIPTION
## Summary
- lighten navigation colors with tan top bar and lighter sidebar
- turn login link into prominent button with larger text

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6893e06fee3c83338886ac9bf85360ec