### PR TITLE
Add event source submission with auth

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -8,11 +8,11 @@ export default function Sidebar() {
         <Link className="nav-link text-dark" to="/">
           Home
         </Link>
-        <Link className="nav-link text-dark" to="/about">
-          About
-        </Link>
         <Link className="nav-link text-dark" to="/calendar">
           Calendar
+        </Link>
+        <Link className="nav-link text-dark" to="/about">
+          About
         </Link>
       </nav>
     </aside>

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -21,3 +21,7 @@ export const AUTH_ENDPOINTS = {
 export const EVENTS_ENDPOINTS = {
   list: `${API_ROOT}/events/`,
 };
+
+export const SOURCES_ENDPOINTS = {
+  list: `${API_ROOT}/sources/`,
+};

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -1,0 +1,16 @@
+.submit-interface.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.submit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 400px;
+}
+
+.submit-form label {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,3 +1,83 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '../auth.jsx';
+import { SOURCES_ENDPOINTS } from '../constants/api.js';
+import './Home.css';
+
 export default function Home() {
-  return <div>Welcome!</div>;
+  const { user, authFetch } = useAuth();
+  const [sources, setSources] = useState([]);
+  const [url, setUrl] = useState('');
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    if (!user) return;
+    async function loadSources() {
+      try {
+        const res = await authFetch(SOURCES_ENDPOINTS.list);
+        if (res.ok) {
+          const data = await res.json();
+          setSources(data);
+        }
+      } catch (err) {
+        console.error('Failed to load sources', err);
+      }
+    }
+    loadSources();
+  }, [user, authFetch]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await authFetch(SOURCES_ENDPOINTS.list, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ base_url: url, name }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setSources((prev) => [...prev, data]);
+        setUrl('');
+        setName('');
+      }
+    } catch (err) {
+      console.error('Failed to submit source', err);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Welcome!</h1>
+      <div className={`submit-interface${user ? '' : ' disabled'}`}>
+        <form onSubmit={handleSubmit} className="submit-form">
+          <label>
+            URL
+            <input
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              required
+            />
+          </label>
+          <label>
+            Name (optional)
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </label>
+          <button type="submit">Submit</button>
+        </form>
+        <h2>Submitted Sites</h2>
+        <ul>
+          {sources.map((s) => (
+            <li key={s.id}>
+              {s.name ? `${s.name} - ${s.base_url}` : s.base_url}
+            </li>
+          ))}
+        </ul>
+      </div>
+      {!user && <p>Please log in to submit event links.</p>}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- Reorder sidebar so About link appears after Calendar
- Allow authenticated users to submit event source URLs on the home page
- Display user-submitted sources and disable submission when logged out

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893e82fdfd4833394fef3343d95bccb