### PR TITLE
chore: condense readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,15 @@
-# React + Vite
+# Superschedules Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Superschedules is an AI-assisted event discovery tool. This React app talks to a Django API.
 
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Vision: chat search, user-supplied sources, continuously updated events
+- Tech: Vite + React, Django + PostgreSQL, Terraform infrastructure
+- Repos: `superschedules_frontend`, `superschedules`, `superschedules_IAC`, `superschedules_collector` (planned)
 
 ## Local development
-
-1. Install dependencies with `npm install`.
-2. Start the dev server with `npm run dev`.
-3. Open [http://localhost:5173](http://localhost:5173) in your browser.
+1. `npm install`
+2. `npm run dev` -> http://localhost:5173
 
 ## API configuration
-
-API endpoints are assembled in [`src/constants/api.js`](src/constants/api.js). Environment-specific variables such as `VITE_API_BASE_URL` and optional `VITE_API_VERSION` live in [`.env.development`](.env.development) and [`.env.production`](.env.production).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+Endpoints: [`src/constants/api.js`](src/constants/api.js).
+Set `VITE_API_BASE_URL` and optional `VITE_API_VERSION` in `.env.development` or `.env.production`.


### PR DESCRIPTION
## Summary
- rewrite README to succinctly describe Superschedules and list supporting repos
- keep only local development steps and API configuration details

## Testing
- `npm test` (fails: no test files)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68962949cb1c8333993aae0a8c695a6e