### PR TITLE
Improve scanner submission UI and style submitted sites list

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -6,7 +6,7 @@ export default function Sidebar() {
     <aside className="sidebar p-3 text-dark">
       <nav className="nav flex-column">
         <Link className="nav-link text-dark" to="/">
-          Home
+          Scanner Control
         </Link>
         <Link className="nav-link text-dark" to="/calendar">
           Calendar

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -14,3 +14,28 @@
   display: flex;
   flex-direction: column;
 }
+
+.sources-box {
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 0.25rem;
+}
+
+.sources-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.sources-table th,
+.sources-table td {
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.sources-table tbody tr:nth-child(odd) {
+  background-color: #fdf5e6;
+}
+
+.sources-table tbody tr:nth-child(even) {
+  background-color: #f5e9da;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -9,6 +9,11 @@ export default function Home() {
   const [url, setUrl] = useState('');
   const [name, setName] = useState('');
 
+  const truncateUrl = (str, length = 50) =>
+    str && str.length > length ? `${str.slice(0, length)}…` : str;
+
+  const formatDate = (d) => (d ? new Date(d).toLocaleDateString() : '');
+
   useEffect(() => {
     if (!user) return;
     async function loadSources() {
@@ -39,36 +44,51 @@ export default function Home() {
 
   return (
     <div>
-      <h1>Welcome!</h1>
+      <h1>Submit a new site to scan</h1>
       <div className={`submit-interface${user ? '' : ' disabled'}`}>
-        <form onSubmit={handleSubmit} className="submit-form">
-          <label>
-            URL
-            <input
-              type="url"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              required
-            />
-          </label>
-          <label>
-            Name (optional)
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-          </label>
-          <button type="submit">Submit</button>
-        </form>
-        <h2>Submitted Sites</h2>
-        <ul>
-          {sources.map((s) => (
-            <li key={s.id}>
-              {s.name ? `${s.name} - ${s.base_url}` : s.base_url}
-            </li>
-          ))}
-        </ul>
+        <div className="p-4 border rounded bg-warning-subtle mb-4">
+          <form onSubmit={handleSubmit} className="submit-form">
+            <label>
+              URL
+              <input
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                required
+              />
+            </label>
+            <label>
+              Name (optional)
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </label>
+            <button type="submit">Submit</button>
+          </form>
+        </div>
+        <div className="sources-box">
+          <h2>Submitted Sites</h2>
+          <table className="sources-table">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>URL</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sources.map((s) => (
+                <tr key={s.id}>
+                  <td>{formatDate(s.created_at)}</td>
+                  <td title={s.base_url}>{truncateUrl(s.base_url)}</td>
+                  <td>{s.status || 'unknown'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
       {!user && <p>Please log in to submit event links.</p>}
     </div>


### PR DESCRIPTION
## Summary
- rename sidebar Home link to "Scanner Control"
- restyle home page to separate submission form and display submitted sites in table with date, truncated URL, and status
- add light brown alternating row styles for submitted sites list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896488eb0ec833395945093fdf06415