### PR TITLE
Expose source metadata in home view

### DIFF
--- a/src/__tests__/Home.test.jsx
+++ b/src/__tests__/Home.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import Home from '../pages/Home.jsx';
+import { AuthContext } from '../auth.jsx';
+
+function renderWithAuth(ui, { sources = [] } = {}) {
+  const value = {
+    user: { token: 'abc' },
+    authFetch: {
+      get: vi.fn().mockResolvedValue({ data: sources }),
+      post: vi.fn(),
+    },
+  };
+  return render(
+    <MemoryRouter>
+      <AuthContext.Provider value={value}>{ui}</AuthContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+describe('Home', () => {
+  it('shows new source fields', async () => {
+    const sources = [
+      {
+        id: 1,
+        base_url: 'https://example.com',
+        date_added: '2024-01-01',
+        last_run_at: '2024-01-02',
+        status: 'not run',
+      },
+    ];
+    renderWithAuth(<Home />, { sources });
+    await screen.findByText('Submitted Sites');
+    expect(screen.getByText('Date Added')).toBeInTheDocument();
+    expect(screen.getByText('Last Run')).toBeInTheDocument();
+    expect(screen.getByText(/not run/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -73,7 +73,8 @@ export default function Home() {
           <table className="sources-table">
             <thead>
               <tr>
-                <th>Date</th>
+                <th>Date Added</th>
+                <th>Last Run</th>
                 <th>URL</th>
                 <th>Status</th>
               </tr>
@@ -81,9 +82,10 @@ export default function Home() {
             <tbody>
               {sources.map((s) => (
                 <tr key={s.id}>
-                  <td>{formatDate(s.created_at)}</td>
+                  <td>{formatDate(s.date_added)}</td>
+                  <td>{formatDate(s.last_run_at)}</td>
                   <td title={s.base_url}>{truncateUrl(s.base_url)}</td>
-                  <td>{s.status || 'unknown'}</td>
+                  <td>{s.status || 'not run'}</td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## Summary
- Show `date_added` and `last_run_at` fields for each source in the Submitted Sites table
- Default source status to "not run" when missing
- Add a unit test verifying source metadata rendering

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68964e1f8b6883339e49bdef8015255b