### PR TITLE
Fix calendar event width and time parsing

### DIFF
--- a/src/pages/Calendar.css
+++ b/src/pages/Calendar.css
@@ -16,3 +16,11 @@
 .event-dialog {
   padding: 1rem;
 }
+
+/* Ensure events span the full width of their columns */
+.rbc-event {
+  width: 100% !important;
+  max-width: 100% !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -73,10 +73,20 @@ export default function CalendarPage() {
         const res = await authFetch.get(
           `${EVENTS_ENDPOINTS.list}?${params.toString()}`,
         );
+        const combineDateTime = (date, time) => {
+          if (!date && !time) return undefined;
+          const dateStr = date || '';
+          const timeStr = time || '';
+          // If date already has time information, use it directly
+          if (dateStr && dateStr.includes('T')) return new Date(dateStr);
+          // Otherwise, combine date and time into an ISO string
+          return new Date(`${dateStr}${timeStr ? `T${timeStr}` : ''}`);
+        };
+
         const mapped = res.data.map((e) => ({
           ...e,
-          start: new Date(e.start ?? e.start_time),
-          end: new Date(e.end ?? e.end_time),
+          start: combineDateTime(e.start, e.start_time),
+          end: combineDateTime(e.end, e.end_time),
         }));
         setEvents(mapped);
       } catch (err) {


### PR DESCRIPTION
## Summary
- Ensure React Big Calendar events span the full column width
- Correctly combine date and time fields when mapping events

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68976f5c708883339a2b6b34efb89679