### PR TITLE
Improve accessibility with landmarks and ARIA

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -136,3 +136,24 @@
   background-color: rgba(13, 202, 240, 0.2);
   border-color: rgba(13, 202, 240, 0.3);
 }
+
+/* Skip link for keyboard navigation */
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--primary-color);
+  color: #fff;
+  z-index: 1000;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,10 +21,13 @@ export default function App() {
       <ThemeProvider>
         <AuthProvider>
           <div className="layout">
+            <a href="#main-content" className="skip-link">
+              Skip to main content
+            </a>
             <TopBar onToggleSidebar={() => setSidebarOpen((o) => !o)} />
             <div className="main">
               {sidebarOpen && <Sidebar />}
-              <div className="content">
+              <main className="content" id="main-content" tabIndex={-1} role="main">
                 <Routes>
                   <Route path="/" element={<Home />} />
                   <Route path="/login" element={<Login />} />
@@ -34,7 +37,7 @@ export default function App() {
                   <Route path="/reset-password" element={<ResetPassword />} />
                   <Route path="/calendar" element={<Calendar />} />
                 </Routes>
-              </div>
+              </main>
             </div>
           </div>
         </AuthProvider>

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -430,21 +430,23 @@ export default function ChatInterface({
   if (!isVisible) return null;
 
   return (
-    <div className="chat-interface">
+    <div className="chat-interface" aria-busy={isLoading}>
       <div className="chat-header">
         <h3>Event Assistant</h3>
         <div className="header-controls">
-          <button 
+          <button
             className="preferences-btn"
             onClick={() => setShowPreferences(true)}
             title="Set your event preferences"
+            aria-label="Set event preferences"
           >
             ⚙️ Preferences
           </button>
-          <button 
+          <button
             className="clear-chat-btn"
             onClick={clearChat}
             title="Clear conversation history"
+            aria-label="Clear conversation history"
           >
             🗑️ Clear Chat
           </button>
@@ -475,7 +477,14 @@ export default function ChatInterface({
         </div>
       </div>
       
-      <div className="chat-messages" ref={chatMessagesRef}>
+      <div
+        className="chat-messages"
+        ref={chatMessagesRef}
+        role="log"
+        aria-label="Chat messages"
+        aria-live="polite"
+        aria-relevant="additions"
+      >
         {messages.map((message) => {
           if (message.type === 'assistant') {
             return (
@@ -509,7 +518,7 @@ export default function ChatInterface({
         })}
         
         {isLoading && (
-          <div className="message assistant">
+          <div className="message assistant" role="status" aria-live="polite">
             <div className="message-content">
               <div className="typing-indicator">
                 <span></span>
@@ -526,6 +535,7 @@ export default function ChatInterface({
       
       <div className="chat-input">
         <textarea
+          aria-label="Message input"
           value={inputMessage}
           onChange={(e) => setInputMessage(e.target.value)}
           onKeyPress={handleKeyPress}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,20 +1,20 @@
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import './Sidebar.css';
 
 export default function Sidebar() {
   return (
-    <aside className="sidebar p-3">
-      <nav className="nav flex-column">
-        <Link className="nav-link sidebar-link" to="/">
-          Scanner Control
-        </Link>
-        <Link className="nav-link sidebar-link" to="/calendar">
-          Calendar
-        </Link>
-        <Link className="nav-link sidebar-link" to="/about">
-          About
-        </Link>
-      </nav>
-    </aside>
-  );
-}
+      <aside className="sidebar p-3">
+        <nav className="nav flex-column" aria-label="Primary">
+          <NavLink className="nav-link sidebar-link" to="/">
+            Scanner Control
+          </NavLink>
+          <NavLink className="nav-link sidebar-link" to="/calendar">
+            Calendar
+          </NavLink>
+          <NavLink className="nav-link sidebar-link" to="/about">
+            About
+          </NavLink>
+        </nav>
+      </aside>
+    );
+  }

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -8,9 +8,10 @@ export default function CalendarPage() {
 
   return (
     <div className="calendar-page-new">
+      <h1>Calendar</h1>
       {/* Chat Section at Top */}
       <div className="chat-section-separate">
-        <ChatInterface 
+        <ChatInterface
           onSuggestedEvents={setSuggestedEvents}
           onSuggestionsLoading={setLoadingSuggestions}
           suggestedEvents={suggestedEvents}

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,1 +1,13 @@
 import '@testing-library/jest-dom/vitest';
+
+// Polyfill matchMedia for tests
+if (!window.matchMedia) {
+  window.matchMedia = () => ({
+    matches: false,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}


### PR DESCRIPTION
## Summary
- add skip-to-content link and main landmark for keyboard users
- enhance chat interface with ARIA labels, live regions, and status updates
- switch sidebar to NavLink and label navigation region
- add heading to calendar page and polyfill matchMedia for tests

## Testing
- `pnpm lint`
- `pnpm test` (fails: 5 failed tests, see logs)

------
https://chatgpt.com/codex/tasks/task_e_68b1f01b77fc833390760aa975dd82df